### PR TITLE
feat: sorting out map types

### DIFF
--- a/src/ot_croissant/assets/distribution.json
+++ b/src/ot_croissant/assets/distribution.json
@@ -185,6 +185,7 @@
   {
     "id": "variant",
     "nice_name": "Variant",
+    "key": ["variant/variantId"],
     "description": "Core variant information for all variants in the Platform. Variants are included if any phenotypic information is available for the variant, including GWAS or molQTL credible sets, ClinVar, Uniprot or PharmGKB. The dataset includes variant metadata as well as variant effects derived from Ensembl VEP."
   },
   {

--- a/src/ot_croissant/constants.py
+++ b/src/ot_croissant/constants.py
@@ -9,4 +9,5 @@ typeDict = {
     "long": mlc.DataType.FLOAT,
     "double": mlc.DataType.FLOAT,
     "integer": mlc.DataType.INTEGER,
+    "float": mlc.DataType.FLOAT,
 }

--- a/src/ot_croissant/crumbs/record_sets.py
+++ b/src/ot_croissant/crumbs/record_sets.py
@@ -54,6 +54,14 @@ class PlatformOutputRecordSets:
         )
         if primary_key:
             record_set.key = primary_key
+
+        # Extract description of dataset:
+        description = DistributionCuration().get_curation(
+            distribution_id=self.DISTRIBUTION_ID, key="description"
+        )
+        if description:
+            record_set.description = description
+
         # Return record set
         return record_set
 


### PR DESCRIPTION
When encountering a map column, the parsing logic models the schema as a list of structs with key/values. As the process models the data as struct, this solution should scale for arbitrarily complicated key/value schemas.