### PR TITLE
feat: making ftp location optional

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -18,7 +18,7 @@ parser.add_argument(
     "--ftp_location",
     type=str,
     help="FTP location",
-    required=True,
+    required=False,
 )
 parser.add_argument(
     "--gcp_location",

--- a/src/ot_croissant/assets/distribution.json
+++ b/src/ot_croissant/assets/distribution.json
@@ -46,11 +46,6 @@
     "description": "This dataset contains the mapping between gene ontology identifiers and terms."
   },
   {
-    "id": "mousePhenotypes",
-    "nice_name": "Target - mouse phenotypes",
-    "description": "Phenotypes observed when knocking-out targets (genes) in mice models as reported by IMPC"
-  },
-  {
     "id": "disease_phenotype",
     "nice_name": "Disease/Phenotype - clinical signs and symptoms",
     "key": ["disease_phenotype/disease", "disease_phenotype/phenotype"],
@@ -252,5 +247,10 @@
     "key": [
       "literature_vector/word"
     ]
+  },
+  {
+    "id": "otar",
+    "nice_name": "Open Targets Projects",
+    "description": "Open Targets projects grouped by studied disease or phenotype."
   }
 ]

--- a/src/ot_croissant/crumbs/distribution.py
+++ b/src/ot_croissant/crumbs/distribution.py
@@ -31,18 +31,28 @@ class PlatformOutputDistribution:
             return f"Automatic {key} of the file set/object '{id}'."
 
     def add_ftp_location(self, ftp_location: str, data_integrity_hash: str):
-        """Add the FTP location of the distribution."""
-        self.distribution.append(
-            FileObject(
-                id="ftp-location",
-                name="FTP location",
-                description="FTP location of the Open Targets Platform data.",
-                encoding_format="https",
-                content_url=ftp_location,
-                sha256=data_integrity_hash,
+        """Add the FTP location of the distribution IF ftp location is not None.
+        
+        Args:
+            ftp_location: The FTP location of the distribution.
+            data_integrity_hash: The data integrity hash of the distribution.
+        
+        Returns:
+            The PlatformOutputDistribution object.
+        """
+        if ftp_location:
+            self.distribution.append(
+                FileObject(
+                    id="ftp-location",
+                    name="FTP location",
+                    description="FTP location of the Open Targets Platform data.",
+                    encoding_format="https",
+                    content_url=ftp_location,
+                    sha256=data_integrity_hash,
+                )
             )
-        )
-        self.contained_in.append("ftp-location")
+            self.contained_in.append("ftp-location")
+
         return self
 
     def add_gcp_location(self, gcp_location: str, data_integrity_hash: str):

--- a/src/ot_croissant/crumbs/metadata.py
+++ b/src/ot_croissant/crumbs/metadata.py
@@ -18,7 +18,7 @@ class PlatformOutputMetadata(Metadata):
     def __init__(
         self,
         datasets: list[str],
-        ftp_location: str,
+        ftp_location: str | None,
         gcp_location: str,
         version: str,
         date_published: str,


### PR DESCRIPTION
## Context

PPP data releases generates slightly different datasets compared to the public release. Some datasets only exported for PPP. Also the outputs are not available via FTP, and the GCP location is different. This needs to be reflected in the resulting croissant descriptions. This PR addresses these issues.

## Testing

Running script without providing ftp location:

```bash
uv run python src/app.py \
    --output test.jsonld \
    -d 'reactome' \
    -d '/Users/dsuveges/project_data/gentropy/variant' \
    --version '25.03' \
    --date_published '2025-03-18' \
    --gcp_location="gs://open-targets-data-releases/24.09/output/etl/parquet/" \
    --data_integrity_hash "aslkdsaflkjad"
```

In the resulting dataset there's no ftp distribution, just gcp:
```json
    {
      "@type": "cr:FileObject",
      "@id": "gcp-location",
      "name": "GCP location",
      "description": "Location of the Open Targets Platform data in Google Cloud Storage.",
      "contentUrl": "gs://open-targets-data-releases/24.09/output/etl/parquet/",
      "encodingFormat": "https",
      "sha256": "aslkdsaflkjad"
    }
```

Datasets are only listed with this distribution:

```json
    {
      "@type": "cr:FileSet",
      "@id": "reactome-fileset",
      "name": "Target - Reactome pathway information",
      "description": "Pathway metadata from Reactome pathway database.",
      "containedIn": {
        "@id": "gcp-location"
      },
      "encodingFormat": "application/x-parquet",
      "includes": "reactome/*.parquet"
    }
```

However if ftp is given:

```json
    {
      "@type": "cr:FileSet",
      "@id": "reactome-fileset",
      "name": "Target - Reactome pathway information",
      "description": "Pathway metadata from Reactome pathway database.",
      "containedIn": [
        {
          "@id": "ftp-location"
        },
        {
          "@id": "gcp-location"
        }
      ],
      "encodingFormat": "application/x-parquet",
      "includes": "reactome/*.parquet"
    }
```