### PR TITLE
fix: documentation following schema change

### DIFF
--- a/src/ot_croissant/assets/recordset.json
+++ b/src/ot_croissant/assets/recordset.json
@@ -1526,11 +1526,11 @@
     "description": "List of identifiers in other databases"
   },
   {
-    "id": "drug_molecule/crossReferences/key",
-    "description": "List of database source name"
+    "id": "drug_molecule/crossReferences/source",
+    "description": "Database source name"
   },
   {
-    "id": "drug_molecule/crossReferences/value",
+    "id": "drug_molecule/crossReferences/ids",
     "description": "List of identifiers in other databases"
   },
   {


### PR DESCRIPTION
As part of the effort to remove map types from ot datasets, the cross references column in the drug-molecule dataset become a list of structs with a different name. That required to change the column level description. These changes were following [#3871](https://github.com/opentargets/issues/issues/3871#issuecomment-2903842205)