### PR TITLE
fix: handling missing tags

### DIFF
--- a/src/ot_croissant/assets/distribution.json
+++ b/src/ot_croissant/assets/distribution.json
@@ -138,7 +138,7 @@
     "nice_name": "Target - Prioritisation",
     "key": ["target_validation/targetId"],
     "description": "Target-specific properties used to prioritise targets for further prioritisation (prioritisation view). All prioritisation factors included in the dataset range from -1 (unfavourable) to 1 (favourable). The prioritisation factors cover several areas around the clinical precedence, tractability, do-ability and safety of a target.",
-    "tags": NaN
+    "tags": null
   },
   {
     "id": "target_essentiality",
@@ -350,6 +350,6 @@
     "nice_name": "Open Targets Projects",
     "key": ["otar/efo_id"],
     "description": "Open Targets projects grouped by studied disease or phenotype.",
-    "tags": NaN
+    "tags": null
   }
 ]

--- a/src/ot_croissant/crumbs/distribution.py
+++ b/src/ot_croissant/crumbs/distribution.py
@@ -37,7 +37,7 @@ class PlatformOutputDistribution:
         )
 
         # Return description if tags are not available:
-        if tags is None:
+        if not isinstance(tags, list):
             return description
 
         # Format tags:
@@ -96,7 +96,6 @@ class PlatformOutputDistribution:
                 ),
                 description=self.generate_distribution_description(id),
                 encoding_formats="application/x-parquet",
-                includes=f"{id}/*.parquet",
             )
 
             if len(self.contained_in) > 0:


### PR DESCRIPTION
## Context

The croissant generation was failing at the tags part, more specifically the handling of tags were not robust:

```txt
File "/opt/platform-output-support/.venv/lib/python3.13/site-packages/ot_croissant/crumbs/distribution.py", line 44, in generate_distribution_description
    return f"{description} [{', '.join(tags)}]"
                             ~~~~~~~~~^^^^^^
TypeError: can only join an iterable
```

This was due to a `NaN` values in the curation file:

```json
  {
    "id": "otar",
    "nice_name": "Open Targets Projects",
    "key": ["otar/efo_id"],
    "description": "Open Targets projects grouped by studied disease or phenotype.",
    "tags": NaN
  }
```

The tag handling was made more robust by testing for matching type.

Also fixing JSON format for missing data:

```json
  {
    "id": "otar",
    "nice_name": "Open Targets Projects",
    "key": ["otar/efo_id"],
    "description": "Open Targets projects grouped by studied disease or phenotype.",
    "tags": null
  }
```