### PR TITLE
fix: filesets has to have includes tag

### DIFF
--- a/src/ot_croissant/crumbs/distribution.py
+++ b/src/ot_croissant/crumbs/distribution.py
@@ -96,6 +96,7 @@ class PlatformOutputDistribution:
                 ),
                 description=self.generate_distribution_description(id),
                 encoding_formats="application/x-parquet",
+                includes=f"{id}/*.parquet"
             )
 
             if len(self.contained_in) > 0:


### PR DESCRIPTION
## Context

When running application with tag `0.1.3`. the following error was thrown: 

```
  File "/Users/dsuveges/repositories/ot_croissant/.venv/lib/python3.10/site-packages/mlcroissant/_src/structure_graph/nodes/metadata.py", line 339, in __post_init__
    raise ValidationError(node.ctx.issues.report())
mlcroissant._src.core.issues.ValidationError: Found the following 1 error(s) during the validation:
  -  [PlatformOutputMetadata(Open Targets Platform Datasets) > FileSet(GWAS Study)] Property "http://mlcommons.org/croissant/includes" is mandatory, but does not exist.
```

This error suggests that filesets need to have a mandatory `"includes"` property, that was not set. I don't know how this worked before, but now it is added.