### PR TITLE
feat: add and update curation annotations for reactome, baseline_expr…

### DIFF
--- a/src/ot_croissant/assets/distribution.json
+++ b/src/ot_croissant/assets/distribution.json
@@ -50,10 +50,11 @@
   {
     "id": "baseline_expression",
     "nice_name": "Baseline expression",
+    "key": ["targetId", "datasourceId", "datatypeId", "tissueBiosampleId", "celltypeBiosampleId"],
     "tags": [
       "Target"
     ],
-    "description": "Baseline bulk RNA-seq, single-cell RNA-seq and MS proteomic expression data across tissues and cell types. This data contains normalised expression values showing how targets are selectively expressed across different tissues. This dataset combines expression values from multiples sources: Tabula Sapiens, Database of Immune Cell Expression, PRIDE and GTEx."
+    "description": "Aggregated expression data generated from RNA-seq and mass spectrometry proteomic data"
   },
   {
     "id": "biosample",
@@ -388,7 +389,7 @@
     "description": "Predictions from our Locus-to-Gene (L2G) gene assignment model. The dataset contains all predictions for every combination of credible set and genes in the region as well as statistics to explain the model interpretation of the predictions"
   },
   {
-    "id": "literature",
+    "id": "literature_entity_lut",
     "nice_name": "Literature",
     "tags": [
       "Literature"
@@ -487,5 +488,14 @@
       "Genetics"
     ],
     "description": "Core variant information for all variants in the Platform. Variants are included if any phenotypic information is available for the variant, including GWAS or molQTL credible sets, ClinVar, Uniprot or ClinPGx. The dataset includes variant metadata as well as variant effects derived from Ensembl VEP"
+  },
+  {
+    "id": "reactome",
+    "nice_name": "Target - Reactome pathway information",
+    "key": "reactome/id",
+    "tags": [
+      "Ontology"
+    ],
+    "description": "Pathway metadata from Reactome pathway database"
   }
 ]

--- a/src/ot_croissant/assets/recordset.json
+++ b/src/ot_croissant/assets/recordset.json
@@ -317,7 +317,7 @@
   },
   {
     "id": "baseline_expression/celltypeBiosampleFromSource",
-    "description": "Tissue reported by study"
+    "description": "Tissue or cell type reported by study"
   },
   {
     "id": "baseline_expression/celltypeBiosampleId",
@@ -357,7 +357,7 @@
   },
   {
     "id": "baseline_expression/qualityControls",
-    "description": "PLACEHOLDER for qualityControls description"
+    "description": "Quality control flags or notes for baseline expression"
   },
   {
     "id": "baseline_expression/q1",
@@ -373,7 +373,7 @@
   },
   {
     "id": "baseline_expression/targetFromSourceId",
-    "description": "PLACEHOLDER for targetFromSourceId description"
+    "description": "Target identifier from the source"
   },
   {
     "id": "baseline_expression/targetId",
@@ -1122,7 +1122,7 @@
   },
   {
     "id": "drug_molecule/molblock",
-    "description": "PLACEHOLDER for molblock description"
+    "description": "Mol Block is a chemical structure file format that serves as a connection table, representing molecules through a list of atoms, bonds, and spatial coordinates"
   },
   {
     "id": "drug_molecule/name",
@@ -3634,11 +3634,11 @@
   },
   {
     "id": "go/ancestors",
-    "description": "PLACEHOLDER for ancestors description"
+    "description": "List of ancestor GO terms"
   },
   {
     "id": "go/descendants",
-    "description": "PLACEHOLDER for descendants description"
+    "description": "List of descendant GO terms"
   },
   {
     "id": "go/altIds",
@@ -4922,7 +4922,7 @@
   },
   {
     "id": "target/subcellularLocations/targetModifier",
-    "description": "PLACEHOLDER for targetModifier description"
+    "description": "Protein isoform or modification that specific for the given subcellular location"
   },
   {
     "id": "target/subcellularLocations/termSL",
@@ -5109,11 +5109,11 @@
   },
   {
     "id": "target_prioritisation/celltypeDistribution",
-    "description": "PLACEHOLDER for celltypeDistribution description"
+    "description": "Describes the distribution pattern of the target's expression in various cell types"
   },
   {
     "id": "target_prioritisation/celltypeSpecificity",
-    "description": "PLACEHOLDER for celltypeSpecificity description"
+    "description": "Describes the specificity of the target's expression across different cell types"
   },
   {
     "id": "target_prioritisation/geneticConstraint",

--- a/src/ot_croissant/assets/recordset.json
+++ b/src/ot_croissant/assets/recordset.json
@@ -356,6 +356,10 @@
     "description": "Minimum value of expression"
   },
   {
+    "id": "baseline_expression/qualityControls",
+    "description": "PLACEHOLDER for qualityControls description"
+  },
+  {
     "id": "baseline_expression/q1",
     "description": "First quantile of expression"
   },
@@ -366,6 +370,10 @@
   {
     "id": "baseline_expression/specificity_score",
     "description": "Measure of how specific expression is to a biosample"
+  },
+  {
+    "id": "baseline_expression/targetFromSourceId",
+    "description": "PLACEHOLDER for targetFromSourceId description"
   },
   {
     "id": "baseline_expression/targetId",
@@ -1111,6 +1119,10 @@
   {
     "id": "drug_molecule/maximumClinicalStage",
     "description": "Display name of the highest clinical stage reached by the drug (e.g. 'approved', 'phase III')"
+  },
+  {
+    "id": "drug_molecule/molblock",
+    "description": "PLACEHOLDER for molblock description"
   },
   {
     "id": "drug_molecule/name",
@@ -3383,6 +3395,35 @@
     "description": "Descriptions of variant consequences at protein level"
   },
   {
+    "id": "reactome/id",
+    "description": "Unique identifier for the Reactome pathway [bioregistry:reactome]",
+    "isPrimaryKey": true
+  },
+  {
+    "id": "reactome/label",
+    "description": "Name or label of the pathway"
+  },
+  {
+    "id": "reactome/ancestors",
+    "description": "List of ancestor pathways in the ontology"
+  },
+  {
+    "id": "reactome/descendants",
+    "description": "List of descendant pathways in the ontology"
+  },
+  {
+    "id": "reactome/children",
+    "description": "Direct child pathways of the current pathway"
+  },
+  {
+    "id": "reactome/parents",
+    "description": "Direct parent pathways of the current pathway"
+  },
+  {
+    "id": "reactome/path",
+    "description": "Hierarchical path representing the position of the pathway in Reactome"
+  },
+  {
     "id": "evidence_uniprot_literature/confidence",
     "description": "Confidence qualifier on the reported evidence"
   },
@@ -3590,6 +3631,14 @@
   {
     "id": "expression/tissues/rna/zscore",
     "description": "Expression zscore"
+  },
+  {
+    "id": "go/ancestors",
+    "description": "PLACEHOLDER for ancestors description"
+  },
+  {
+    "id": "go/descendants",
+    "description": "PLACEHOLDER for descendants description"
   },
   {
     "id": "go/altIds",
@@ -3927,42 +3976,42 @@
     "isPrimaryKey": true
   },
   {
-    "id": "literature/date",
+    "id": "literature_entity_lut/date",
     "description": "Date of publication in YYYY-MM-DD format"
   },
   {
-    "id": "literature/day",
+    "id": "literature_entity_lut/day",
     "description": "Day of publication"
   },
   {
-    "id": "literature/keywordId",
+    "id": "literature_entity_lut/keywordId",
     "description": "Unique identifier for the keyword associated with the literature entry",
     "isPrimaryKey": true
   },
   {
-    "id": "literature/keywordType",
+    "id": "literature_entity_lut/keywordType",
     "description": "Type of keyword identified in the literature entry. Values: DS: disease/syndrome, GP: gene/protein, CD: chemical/drug"
   },
   {
-    "id": "literature/month",
+    "id": "literature_entity_lut/month",
     "description": "Month of publication"
   },
   {
-    "id": "literature/pmcid",
+    "id": "literature_entity_lut/pmcid",
     "description": "PubMed Central ID (PMCID) of the literature entry",
     "isPrimaryKey": true
   },
   {
-    "id": "literature/pmid",
+    "id": "literature_entity_lut/pmid",
     "description": "Europe PubMed Central identifier (EPMCID) of the literature entry",
     "isPrimaryKey": true
   },
   {
-    "id": "literature/relevance",
+    "id": "literature_entity_lut/relevance",
     "description": "Relevance score of the keyword within the literature entry"
   },
   {
-    "id": "literature/year",
+    "id": "literature_entity_lut/year",
     "description": "Year of publication"
   },
   {
@@ -4362,7 +4411,7 @@
   {
     "id": "study/pubmedId",
     "description": "PubMed identifier of the publication that references the study [bioregistry:pubmed]",
-    "foreign_key": "literature/pmid"
+    "foreign_key": "literature_entity_lut/pmid"
   },
   {
     "id": "study/qualityControls",
@@ -4872,6 +4921,10 @@
     "description": "Source database for the subcellular location"
   },
   {
+    "id": "target/subcellularLocations/targetModifier",
+    "description": "PLACEHOLDER for targetModifier description"
+  },
+  {
     "id": "target/subcellularLocations/termSL",
     "description": "Subcellular location term identifier from SwissProt [bioregistry:sl]"
   },
@@ -5053,6 +5106,14 @@
     "description": "Target identifier the essentiality was measured on [bioregistry:ensembl]",
     "foreign_key": "target/id",
     "isPrimaryKey": true
+  },
+  {
+    "id": "target_prioritisation/celltypeDistribution",
+    "description": "PLACEHOLDER for celltypeDistribution description"
+  },
+  {
+    "id": "target_prioritisation/celltypeSpecificity",
+    "description": "PLACEHOLDER for celltypeSpecificity description"
   },
   {
     "id": "target_prioritisation/geneticConstraint",


### PR DESCRIPTION
…ession, and literature_entity_lut datasets

- Add distribution entry for reactome with key, nice_name, description, and tags
- Update baseline_expression distribution with key fields and revised description
- Rename literature → literature_entity_lut in distribution.json and recordset.json
- Add reactome column descriptions to recordset.json
- Add placeholder descriptions for missing fields: go/ancestors, go/descendants, drug_molecule/molblock, target_prioritisation/celltypeDistribution, target_prioritisation/celltypeSpecificity, target/subcellularLocations/targetModifier, baseline_expression/qualityControls, baseline_expression/targetFromSourceId