### PR TITLE
feat: document drug_molecule synonyms/tradeNames {label, source} subfields

### DIFF
--- a/src/ot_croissant/assets/recordset/drug_molecule.json
+++ b/src/ot_croissant/assets/recordset/drug_molecule.json
@@ -57,7 +57,23 @@
     "description": "List of alternative names for the drug"
   },
   {
+    "id": "synonyms/label",
+    "description": "The alternative name (synonym) for the drug"
+  },
+  {
+    "id": "synonyms/source",
+    "description": "Source of the synonym (e.g. ChEMBL, or AACT for names mined from clinical trials)"
+  },
+  {
     "id": "tradeNames",
     "description": "List of brand names for the drug"
+  },
+  {
+    "id": "tradeNames/label",
+    "description": "The brand (trade) name for the drug"
+  },
+  {
+    "id": "tradeNames/source",
+    "description": "Source of the trade name (e.g. ChEMBL)"
   }
 ]


### PR DESCRIPTION
## Summary

`drug_molecule`'s `synonyms` and `tradeNames` fields changed from `array<string>` to `array<struct<label, source>>` (opentargets/pts#142, tracking issue opentargets/issues#4414) — each name now carries provenance (`ChEMBL`, or `AACT` for names mined from clinical trials).

The Parquet schema introspection in `record_sets.py` picks up the new struct subfields automatically (it recurses into `array<struct>` element types). But those subfields had no curated description, so they would be published with `"PLACEHOLDER for <name> description"`.

This adds curation entries for the four new subfields, mirroring the existing `crossReferences/ids` + `crossReferences/source` pattern:

- `synonyms/label`, `synonyms/source`
- `tradeNames/label`, `tradeNames/source`

`drug_molecule` is the only affected dataset — the other `synonyms` fields (disease, target, biosample) are unrelated schemas, and the search/openfda outputs flatten these to strings.

## Test plan

- [x] `pytest tests/test_recordset_curation.py` — 8 passed (valid JSON, model-conformant, no dup ids, no dataset-prefix leak, FK integrity)
